### PR TITLE
Ensure neo.sh can be called from everywhere

### DIFF
--- a/s4sdk-docker-neo-cli/Dockerfile
+++ b/s4sdk-docker-neo-cli/Dockerfile
@@ -5,4 +5,5 @@ RUN apt-get install -y maven
 
 RUN mvn com.sap.cloud:neo-javaee6-wp-maven-plugin:2.123.9:install-sdk -DsdkInstallPath=sdk -Dincludes=tools/**,license/**,sdk.version
 
-RUN chmod -R 777 sdk
+RUN chmod -R 777 sdk && \
+    ln -s /sdk/tools/neo.sh /usr/bin/neo.sh


### PR DESCRIPTION
In order to be able to simply say 'neo.sh' everywhere we put a
symbolic link into '/usr/bin'.